### PR TITLE
Enable custom tests directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,21 @@ code --install-extension testgen.copilot-assistant
 # Generate tests for a single file
 testgen --file src/calculator.py --output tests/
 
-# Analyze entire project
+# Analyze entire project and enforce 90% coverage
 testgen --project . --security-scan --coverage-target 90
+
+# Check coverage only (no test generation)
+# default tests directory is 'tests'
+testgen --project . --coverage-target 80
+
+# Use a custom tests directory
+testgen --project . --coverage-target 80 --tests-dir mytests
+
+# Show missing functions when checking coverage
+testgen --project . --coverage-target 80 --show-missing
+
+# Enforce test quality score
+testgen --project . --quality-target 90
 
 # Watch mode for continuous testing
 testgen --watch src/ --auto-generate
@@ -209,6 +222,29 @@ from testgen import TestGenerator
 generator = TestGenerator(language='python')
 tests = generator.generate_tests('src/calculator.py')
 security_report = generator.analyze_security('src/')
+```
+
+### Coverage Analysis
+```python
+from testgen_copilot import CoverageAnalyzer
+
+analyzer = CoverageAnalyzer()
+percent = analyzer.analyze('src/calculator.py', 'tests')  # or any tests directory
+print(f"Calculator module covered: {percent:.1f}%")
+```
+
+### Test Quality Scoring
+```python
+from testgen_copilot import TestQualityScorer
+
+scorer = TestQualityScorer()
+quality = scorer.score('tests')
+print(f"Test suite quality: {quality:.1f}%")
+```
+
+Use `--quality-target` on the CLI to enforce a minimum score:
+```bash
+testgen --project . --quality-target 90
 ```
 
 ## Contributing

--- a/src/testgen_copilot/__init__.py
+++ b/src/testgen_copilot/__init__.py
@@ -4,6 +4,8 @@ from .core import identity
 from .generator import GenerationConfig, TestGenerator
 from .security import SecurityScanner, SecurityIssue, SecurityReport
 from .vscode import scaffold_extension, suggest_from_diagnostics, write_usage_docs
+from .coverage import CoverageAnalyzer
+from .quality import TestQualityScorer
 
 __all__ = [
     "identity",
@@ -15,4 +17,6 @@ __all__ = [
     "scaffold_extension",
     "suggest_from_diagnostics",
     "write_usage_docs",
+    "CoverageAnalyzer",
+    "TestQualityScorer",
 ]

--- a/src/testgen_copilot/cli.py
+++ b/src/testgen_copilot/cli.py
@@ -4,9 +4,42 @@ from __future__ import annotations
 
 import argparse
 
+from pathlib import Path
+
 from .generator import GenerationConfig, TestGenerator
 from .security import SecurityScanner
 from .vscode import scaffold_extension
+from .coverage import CoverageAnalyzer
+from .quality import TestQualityScorer
+
+
+def _coverage_failures(
+    project_dir: str | Path, target: float, tests_dir: str | Path | None = None
+) -> list[tuple[str, float, set[str]]]:
+    """Return modules below ``target`` with their uncovered functions."""
+    analyzer = CoverageAnalyzer()
+    project = Path(project_dir)
+    tests_dir = Path(tests_dir) if tests_dir else Path("tests")
+    if not tests_dir.is_absolute():
+        tests_dir = project / tests_dir
+    failures: list[tuple[str, float, set[str]]] = []
+    for path in project.rglob("*.py"):
+        if tests_dir in path.parents:
+            continue
+        cov = analyzer.analyze(path, tests_dir)
+        if cov < target:
+            missing = analyzer.uncovered_functions(path, tests_dir)
+            failures.append((str(path.relative_to(project)), cov, missing))
+    return failures
+
+
+def _check_project_coverage(
+    project_dir: str | Path, target: float, tests_dir: str | Path | None = None
+) -> list[str]:
+    """Return list of modules that fail the coverage ``target``."""
+    return [
+        f"{m}: {c:.1f}%" for m, c, _ in _coverage_failures(project_dir, target, tests_dir)
+    ]
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -29,6 +62,26 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--security-scan", action="store_true", help="Run security analysis"
     )
+    parser.add_argument(
+        "--coverage-target",
+        type=float,
+        help="Fail if project coverage is below this percentage",
+    )
+    parser.add_argument(
+        "--quality-target",
+        type=float,
+        help="Fail if test quality is below this percentage",
+    )
+    parser.add_argument(
+        "--tests-dir",
+        default="tests",
+        help="Location of test files relative to the project root",
+    )
+    parser.add_argument(
+        "--show-missing",
+        action="store_true",
+        help="List uncovered functions for modules below the coverage target",
+    )
 
     args = parser.parse_args(argv)
 
@@ -37,10 +90,46 @@ def main(argv: list[str] | None = None) -> None:
         print(f"VS Code extension scaffolded at {path.parent}")
         return
 
-    if not args.file or not args.output:
+    is_generating = args.file and args.output
+    analysis_only = (
+        (args.coverage_target is not None or args.quality_target is not None)
+        and args.project
+        and not is_generating
+    )
+
+    if not is_generating and not analysis_only:
         parser.error(
-            "--file and --output are required unless --scaffold-vscode is used"
+            "--file and --output are required unless --scaffold-vscode or "
+            "--coverage-target/--quality-target with --project is used"
         )
+
+    if analysis_only:
+        if args.coverage_target is not None:
+            failures = _coverage_failures(args.project, args.coverage_target, args.tests_dir)
+            if failures:
+                print("Coverage below target:")
+                for mod, cov, missing in failures:
+                    print(f"  {mod}: {cov:.1f}%")
+                    if args.show_missing and missing:
+                        names = ", ".join(sorted(missing))
+                        print(f"    Missing: {names}")
+                parser.exit(status=1, message="Coverage target not met\n")
+            print("Coverage target satisfied")
+        if args.quality_target is not None:
+            tests_dir = Path(args.tests_dir)
+            if not tests_dir.is_absolute():
+                tests_dir = Path(args.project) / tests_dir
+            scorer = TestQualityScorer()
+            score = scorer.score(tests_dir)
+            if score < args.quality_target:
+                print(f"Test quality: {score:.1f}%")
+                lacking = scorer.low_quality_tests(tests_dir)
+                if lacking:
+                    names = ", ".join(sorted(lacking))
+                    print(f"  Missing asserts in: {names}")
+                parser.exit(status=1, message="Quality target not met\n")
+            print("Quality target satisfied")
+        return
 
     config = GenerationConfig(language=args.language)
     generator = TestGenerator(config)
@@ -55,6 +144,31 @@ def main(argv: list[str] | None = None) -> None:
         )
         for rep in reports:
             print(rep.to_text())
+    if args.coverage_target is not None and args.project:
+        failures = _coverage_failures(args.project, args.coverage_target, args.tests_dir)
+        if failures:
+            print("Coverage below target:")
+            for mod, cov, missing in failures:
+                print(f"  {mod}: {cov:.1f}%")
+                if args.show_missing and missing:
+                    names = ", ".join(sorted(missing))
+                    print(f"    Missing: {names}")
+            parser.exit(status=1, message="Coverage target not met\n")
+        print("Coverage target satisfied")
+    if args.quality_target is not None and args.project:
+        tests_dir = Path(args.tests_dir)
+        if not tests_dir.is_absolute():
+            tests_dir = Path(args.project) / tests_dir
+        scorer = TestQualityScorer()
+        score = scorer.score(tests_dir)
+        if score < args.quality_target:
+            print(f"Test quality: {score:.1f}%")
+            lacking = scorer.low_quality_tests(tests_dir)
+            if lacking:
+                names = ", ".join(sorted(lacking))
+                print(f"  Missing asserts in: {names}")
+            parser.exit(status=1, message="Quality target not met\n")
+        print("Quality target satisfied")
     print(f"Generated tests -> {output_path}")
 
 

--- a/src/testgen_copilot/coverage.py
+++ b/src/testgen_copilot/coverage.py
@@ -1,0 +1,75 @@
+"""Simple code coverage estimation utilities."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Iterable
+
+
+class CoverageAnalyzer:
+    """Estimate coverage of tests over a source file."""
+
+    def analyze(self, source_path: str | Path, tests_dir: str | Path) -> float:
+        """Return the percentage of source functions referenced in tests."""
+        src = Path(source_path)
+        tests = Path(tests_dir)
+
+        func_names = self._functions_in_file(src)
+        if not func_names:
+            return 100.0
+
+        covered = self._functions_used_in_tests(tests, func_names)
+        return (len(covered) / len(func_names)) * 100
+
+    def uncovered_functions(
+        self, source_path: str | Path, tests_dir: str | Path
+    ) -> set[str]:
+        """Return names of functions in ``source_path`` not referenced by tests."""
+        src = Path(source_path)
+        tests = Path(tests_dir)
+
+        func_names = self._functions_in_file(src)
+        if not func_names:
+            return set()
+
+        covered = self._functions_used_in_tests(tests, func_names)
+        return set(func_names) - covered
+
+    @staticmethod
+    def _functions_in_file(path: Path) -> list[str]:
+        """Return all function and method names defined in ``path``."""
+        tree = ast.parse(path.read_text())
+        return [
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]
+
+    @staticmethod
+    def _functions_used_in_tests(tests_dir: Path, func_names: Iterable[str]) -> set[str]:
+        """Return the subset of ``func_names`` referenced within ``tests_dir``."""
+        names = set(func_names)
+        covered: set[str] = set()
+        for test_file in tests_dir.rglob("test_*.py"):
+            tree = ast.parse(test_file.read_text())
+
+            # Track aliases from ``from x import y as z`` so calls to ``z`` are
+            # associated with ``y`` when checking coverage.
+            alias_map = {}
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom):
+                    for alias in node.names:
+                        if alias.asname and alias.name in names:
+                            alias_map[alias.asname] = alias.name
+
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Name):
+                    if isinstance(node.ctx, ast.Load):
+                        target = alias_map.get(node.id, node.id)
+                        if target in names:
+                            covered.add(target)
+                elif isinstance(node, ast.Attribute):
+                    if isinstance(node.ctx, ast.Load) and node.attr in names:
+                        covered.add(node.attr)
+        return covered

--- a/src/testgen_copilot/quality.py
+++ b/src/testgen_copilot/quality.py
@@ -1,0 +1,38 @@
+"""Utilities to score the quality of test files."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+class TestQualityScorer:
+    """Estimate quality of tests based on presence of assertions."""
+
+    def score(self, tests_dir: str | Path) -> float:
+        """Return percentage of test functions containing ``assert`` statements."""
+        tests = Path(tests_dir)
+        total = 0
+        with_assert = 0
+        for path in tests.rglob("test_*.py"):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test"):
+                    total += 1
+                    if any(isinstance(n, ast.Assert) for n in ast.walk(node)):
+                        with_assert += 1
+        if total == 0:
+            return 100.0
+        return (with_assert / total) * 100
+
+    def low_quality_tests(self, tests_dir: str | Path) -> set[str]:
+        """Return names of test functions lacking assertions."""
+        tests = Path(tests_dir)
+        lacking: set[str] = set()
+        for path in tests.rglob("test_*.py"):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test"):
+                    if not any(isinstance(n, ast.Assert) for n in ast.walk(node)):
+                        lacking.add(node.name)
+        return lacking

--- a/testgen_copilot/__init__.py
+++ b/testgen_copilot/__init__.py
@@ -1,5 +1,0 @@
-"""TestGen Copilot package."""
-
-from .core import identity
-
-__all__ = ["identity"]

--- a/testgen_copilot/core.py
+++ b/testgen_copilot/core.py
@@ -1,6 +1,0 @@
-"""Core utilities for TestGen Copilot."""
-
-
-def identity(value):
-    """Return the input value as-is."""
-    return value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure 'src' directory is on sys.path so tests can import the package without installation
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,109 @@
+import pytest
+
+from testgen_copilot.cli import main
+
+
+def _make_project(
+    tmp_path, *, dir_name: str = "tests", covered: bool = True, quality: bool = True
+):
+    src = tmp_path / "sample.py"
+    src.write_text("""def a():\n    pass\n\n""")
+    tests_dir = tmp_path / dir_name
+    tests_dir.mkdir()
+    if covered:
+        if quality:
+            (tests_dir / "test_sample.py").write_text(
+                """from sample import a
+
+def test_a():
+    assert a() is None
+"""
+            )
+        else:
+            (tests_dir / "test_sample.py").write_text(
+                """from sample import a
+
+def test_a():
+    a()
+"""
+            )
+    else:
+        if quality:
+            (tests_dir / "test_sample.py").write_text(
+                """def test_dummy():
+    assert True
+"""
+            )
+        else:
+            (tests_dir / "test_sample.py").write_text(
+                """def test_dummy():
+    pass
+"""
+            )
+    return src
+
+
+def test_cli_coverage_only_pass(tmp_path, capsys):
+    _make_project(tmp_path, covered=True)
+    main(["--project", str(tmp_path), "--coverage-target", "100"])
+    out = capsys.readouterr().out
+    assert "Coverage target satisfied" in out
+
+
+def test_cli_coverage_only_fail(tmp_path):
+    _make_project(tmp_path, covered=False)
+    with pytest.raises(SystemExit) as exc:
+        main(["--project", str(tmp_path), "--coverage-target", "100"])
+    assert exc.value.code == 1
+
+
+def test_cli_show_missing(tmp_path, capsys):
+    _make_project(tmp_path, covered=False)
+    with pytest.raises(SystemExit):
+        main([
+            "--project",
+            str(tmp_path),
+            "--coverage-target",
+            "100",
+            "--show-missing",
+        ])
+    out = capsys.readouterr().out
+    assert "Missing: a" in out
+
+
+def test_cli_custom_tests_dir(tmp_path, capsys):
+    _make_project(tmp_path, dir_name="unit", covered=True)
+    main([
+        "--project",
+        str(tmp_path),
+        "--coverage-target",
+        "100",
+        "--tests-dir",
+        "unit",
+    ])
+    out = capsys.readouterr().out
+    assert "Coverage target satisfied" in out
+
+
+def test_cli_quality_only_pass(tmp_path, capsys):
+    _make_project(tmp_path, quality=True)
+    main([
+        "--project",
+        str(tmp_path),
+        "--quality-target",
+        "100",
+    ])
+    out = capsys.readouterr().out
+    assert "Quality target satisfied" in out
+
+
+def test_cli_quality_only_fail(tmp_path):
+    _make_project(tmp_path, quality=False)
+    with pytest.raises(SystemExit) as exc:
+        main([
+            "--project",
+            str(tmp_path),
+            "--quality-target",
+            "100",
+        ])
+    assert exc.value.code == 1

--- a/tests/test_coverage_analysis.py
+++ b/tests/test_coverage_analysis.py
@@ -1,0 +1,227 @@
+from testgen_copilot.coverage import CoverageAnalyzer
+
+
+def test_basic_coverage(tmp_path):
+    src = tmp_path / "sample.py"
+    src.write_text(
+        """
+def a():
+    pass
+
+def b():
+    pass
+"""
+    )
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_sample.py").write_text(
+        """
+from sample import a
+
+def test_a():
+    a()
+"""
+    )
+
+    analyzer = CoverageAnalyzer()
+    percent = analyzer.analyze(src, tests_dir)
+    assert percent == 50.0
+
+
+def test_no_functions(tmp_path):
+    src = tmp_path / "empty.py"
+    src.write_text("pass\n")
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    analyzer = CoverageAnalyzer()
+    assert analyzer.analyze(src, tests_dir) == 100.0
+
+
+def test_names_in_comments_not_counted(tmp_path):
+    src = tmp_path / "sample.py"
+    src.write_text(
+        """
+def a():
+    pass
+
+def b():
+    pass
+"""
+    )
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_sample.py").write_text(
+        """
+from sample import a
+
+def test_a():  # b should not be counted
+    a()
+"""
+    )
+
+    analyzer = CoverageAnalyzer()
+    assert analyzer.analyze(src, tests_dir) == 50.0
+
+
+def test_attribute_call_is_detected(tmp_path):
+    src = tmp_path / "sample.py"
+    src.write_text(
+        """
+def a():
+    pass
+
+def b():
+    pass
+"""
+    )
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_sample.py").write_text(
+        """
+import sample
+
+def test_a():
+    sample.a()
+"""
+    )
+
+    analyzer = CoverageAnalyzer()
+    assert analyzer.analyze(src, tests_dir) == 50.0
+
+
+def test_nested_test_dirs(tmp_path):
+    """Files in subdirectories should be considered."""
+    src = tmp_path / "sample.py"
+    src.write_text(
+        """
+def a():
+    pass
+"""
+    )
+
+    sub = tmp_path / "tests" / "unit"
+    sub.mkdir(parents=True)
+    (sub / "test_sample.py").write_text(
+        """
+from sample import a
+
+def test_a():
+    a()
+"""
+    )
+
+    analyzer = CoverageAnalyzer()
+    assert analyzer.analyze(src, tmp_path / "tests") == 100.0
+
+
+def test_class_methods_counted(tmp_path):
+    src = tmp_path / "sample.py"
+    src.write_text(
+        """
+class C:
+    def a(self):
+        pass
+
+    def b(self):
+        pass
+"""
+    )
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_sample.py").write_text(
+        """
+from sample import C
+
+def test_a():
+    C().a()
+"""
+    )
+
+    analyzer = CoverageAnalyzer()
+    assert analyzer.analyze(src, tests_dir) == 50.0
+
+
+def test_alias_imports_are_detected(tmp_path):
+    src = tmp_path / "sample.py"
+    src.write_text(
+        """
+def a():
+    pass
+
+def b():
+    pass
+"""
+    )
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_sample.py").write_text(
+        """
+from sample import a as alias_a
+
+def test_a():
+    alias_a()
+"""
+    )
+
+    analyzer = CoverageAnalyzer()
+    assert analyzer.analyze(src, tests_dir) == 50.0
+
+
+def test_module_aliases_are_detected(tmp_path):
+    src = tmp_path / "sample.py"
+    src.write_text(
+        """
+def a():
+    pass
+
+def b():
+    pass
+"""
+    )
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_sample.py").write_text(
+        """
+import sample as alias_mod
+
+def test_a():
+    alias_mod.a()
+"""
+    )
+
+    analyzer = CoverageAnalyzer()
+    assert analyzer.analyze(src, tests_dir) == 50.0
+
+
+def test_uncovered_functions_report(tmp_path):
+    src = tmp_path / "sample.py"
+    src.write_text(
+        """
+def a():
+    pass
+
+def b():
+    pass
+"""
+    )
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_sample.py").write_text(
+        """
+from sample import a
+
+def test_a():
+    a()
+"""
+    )
+
+    analyzer = CoverageAnalyzer()
+    missing = analyzer.uncovered_functions(src, tests_dir)
+    assert missing == {"b"}

--- a/tests/test_quality_scoring.py
+++ b/tests/test_quality_scoring.py
@@ -1,0 +1,44 @@
+from testgen_copilot.quality import TestQualityScorer
+
+
+def _make_tests(tmp_path, with_assert: bool = True):
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    if with_assert:
+        (tests_dir / "test_sample.py").write_text(
+            """
+
+def test_ok():
+    assert True
+"""
+        )
+    else:
+        (tests_dir / "test_sample.py").write_text(
+            """
+
+def test_bad():
+    pass
+"""
+        )
+    return tests_dir
+
+
+def test_quality_full_score(tmp_path):
+    tests_dir = _make_tests(tmp_path, with_assert=True)
+    scorer = TestQualityScorer()
+    assert scorer.score(tests_dir) == 100.0
+
+
+def test_quality_partial_score(tmp_path):
+    tests_dir = _make_tests(tmp_path, with_assert=False)
+    scorer = TestQualityScorer()
+    assert scorer.score(tests_dir) == 0.0
+    assert scorer.low_quality_tests(tests_dir) == {"test_bad"}
+
+
+def test_no_tests(tmp_path):
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    scorer = TestQualityScorer()
+    assert scorer.score(tests_dir) == 100.0
+    assert scorer.low_quality_tests(tests_dir) == set()


### PR DESCRIPTION
## Summary
- allow specifying `--tests-dir` on the CLI
- update CLI coverage logic to respect custom test locations
- document optional `--tests-dir` flag in README
- test custom tests directory behavior
- add a simple test quality scorer utility
- document test quality scoring in README
- test quality scoring module
- introduce `--quality-target` CLI option and tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e887988d48329a7b58b16829961d7