### PR TITLE
Add integration test generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ code --install-extension testgen.copilot-assistant
 # Generate tests for a single file
 testgen --file src/calculator.py --output tests/
 
+# Generate tests for every file in a project
+testgen --project . --output tests --batch  # requires --project and --output only
+
+# Use a configuration file
+testgen --config myconfig.json --file src/calculator.py --output tests
+# A file named `.testgen.config.json` in the current or project directory
+# is loaded automatically when present
+
 # Analyze entire project and enforce 90% coverage
 testgen --project . --security-scan --coverage-target 90
 
@@ -49,8 +57,22 @@ testgen --project . --coverage-target 80 --show-missing
 # Enforce test quality score
 testgen --project . --quality-target 90
 
+# Skip edge case tests
+testgen --file src/calculator.py --output tests --no-edge-cases
+
+# Skip error path tests
+testgen --file src/calculator.py --output tests --no-error-tests
+
+# Skip benchmark tests
+testgen --file src/calculator.py --output tests --no-benchmark-tests
+
+# Skip integration tests
+testgen --file src/calculator.py --output tests --no-integration-tests
+
 # Watch mode for continuous testing
-testgen --watch src/ --auto-generate
+# pass `--auto-generate` to write tests automatically
+# adjust polling interval with --poll (seconds)
+testgen --watch src/ --output tests --auto-generate --poll 2.0
 ```
 
 ### VS Code Integration
@@ -78,7 +100,7 @@ Create `.testgen.config.json` in your project root:
     "edge_cases": true,
     "error_handling": true,
     "mocking": true,
-    "integration_scenarios": false
+    "integration_scenarios": false  # disable integration tests
   },
   "output": {
     "format": "standard",

--- a/tests/test_benchmark_generation.py
+++ b/tests/test_benchmark_generation.py
@@ -1,0 +1,21 @@
+from testgen_copilot.generator import TestGenerator, GenerationConfig
+
+
+def test_benchmark_test_generated(tmp_path):
+    src = tmp_path / "mod.py"
+    src.write_text("def f(x):\n    return x * 2\n")
+    out = tmp_path / "tests"
+    gen = TestGenerator(GenerationConfig(include_benchmarks=True))
+    gen.generate_tests(src, out)
+    content = (out / "test_mod.py").read_text()
+    assert "benchmark(" in content
+
+
+def test_benchmark_tests_can_be_disabled(tmp_path):
+    src = tmp_path / "mod.py"
+    src.write_text("def f(x):\n    return x * 2\n")
+    out = tmp_path / "tests"
+    gen = TestGenerator(GenerationConfig(include_benchmarks=False))
+    gen.generate_tests(src, out)
+    content = (out / "test_mod.py").read_text()
+    assert "benchmark(" not in content

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,17 @@
+import json
 import pytest
+from pathlib import Path
 
-from testgen_copilot.cli import main
+from testgen_copilot.generator import TestGenerator as TG
+
+from testgen_copilot.cli import _language_pattern, main
+
+
+def test_language_pattern_defaults_to_extension():
+    assert _language_pattern("python") == "*.py"
+    assert _language_pattern("Py") == "*.py"
+    assert _language_pattern("csharp") == "*.cs"
+    assert _language_pattern("unknown") == "*unknown"
 
 
 def _make_project(
@@ -107,3 +118,209 @@ def test_cli_quality_only_fail(tmp_path):
             "100",
         ])
     assert exc.value.code == 1
+
+
+def test_cli_batch_generation(tmp_path):
+    src1 = tmp_path / "a.py"
+    src1.write_text("def foo():\n    pass\n")
+    sub = tmp_path / "pkg"
+    sub.mkdir()
+    src2 = sub / "b.py"
+    src2.write_text("def bar():\n    pass\n")
+    out = tmp_path / "tests"
+    main(["--project", str(tmp_path), "--output", str(out), "--batch"])
+    assert (out / "test_a.py").exists()
+    assert (out / "test_b.py").exists()
+
+
+def test_cli_batch_requires_project(tmp_path):
+    out = tmp_path / "tests"
+    with pytest.raises(SystemExit):
+        main(["--output", str(out), "--batch"])
+
+
+def test_cli_batch_requires_output(tmp_path):
+    with pytest.raises(SystemExit):
+        main(["--project", str(tmp_path), "--batch"])
+
+
+def test_cli_batch_no_file_allowed(tmp_path):
+    out = tmp_path / "tests"
+    with pytest.raises(SystemExit):
+        main([
+            "--project",
+            str(tmp_path),
+            "--output",
+            str(out),
+            "--batch",
+            "--file",
+            str(tmp_path / "a.py"),
+        ])
+
+
+def test_cli_watch_auto_generation(tmp_path, monkeypatch):
+    src = tmp_path / "src"
+    src.mkdir()
+    file = src / "a.py"
+    file.write_text("def foo():\n    pass\n")
+    out = tmp_path / "tests"
+
+    called = {}
+
+    def fake_watch(directory, generator, out_dir, pattern, poll=1.0, *, auto_generate=False, max_cycles=None):
+        called["auto"] = auto_generate
+        called["poll"] = poll
+        if auto_generate:
+            generator.generate_tests(file, out_dir)
+
+    monkeypatch.setattr("testgen_copilot.cli._watch_for_changes", fake_watch)
+    main(["--watch", str(src), "--output", str(out), "--auto-generate", "--poll", "2.0"])
+    assert called.get("auto") is True
+    assert called.get("poll") == 2.0
+    assert (out / "test_a.py").exists()
+
+
+def test_cli_watch_change_report_only(tmp_path, monkeypatch):
+    src = tmp_path / "src"
+    src.mkdir()
+    out = tmp_path / "tests"
+
+    called = {}
+
+    def fake_watch(directory, generator, out_dir, pattern, poll=1.0, *, auto_generate=False, max_cycles=None):
+        called["auto"] = auto_generate
+        called["poll"] = poll
+
+    monkeypatch.setattr("testgen_copilot.cli._watch_for_changes", fake_watch)
+    main(["--watch", str(src), "--output", str(out)])
+    assert called.get("auto") is False
+    assert called.get("poll") == 1.0
+    assert not list(out.glob("test_*.py"))
+
+
+def test_cli_watch_requires_output(tmp_path):
+    with pytest.raises(SystemExit):
+        main(["--watch", str(tmp_path)])
+
+
+def test_cli_watch_no_file_allowed(tmp_path):
+    file = tmp_path / "a.py"
+    file.write_text("""
+def foo():
+    pass
+""")
+    out = tmp_path / "tests"
+    with pytest.raises(SystemExit):
+        main([
+            "--watch",
+            str(tmp_path),
+            "--output",
+            str(out),
+            "--file",
+            str(file),
+        ])
+
+
+def test_cli_no_edge_cases_flag(tmp_path, monkeypatch):
+    src = tmp_path / "a.py"
+    src.write_text("def foo():\n    pass\n")
+    out = tmp_path / "tests"
+
+    config_values = {}
+
+    def fake_generate(self, file_path, output_dir):
+        config_values["include_edge_cases"] = self.config.include_edge_cases
+        return Path(output_dir) / "test_a.py"
+
+    monkeypatch.setattr(TG, "generate_tests", fake_generate)
+    main(["--file", str(src), "--output", str(out), "--no-edge-cases"])
+    assert config_values["include_edge_cases"] is False
+
+
+def test_cli_no_error_tests_flag(tmp_path, monkeypatch):
+    src = tmp_path / "a.py"
+    src.write_text("def foo(x):\n    if x < 0:\n        raise ValueError\n")
+    out = tmp_path / "tests"
+
+    config_values = {}
+
+    def fake_generate(self, file_path, output_dir):
+        config_values["include_error_paths"] = self.config.include_error_paths
+        return Path(output_dir) / "test_a.py"
+
+    monkeypatch.setattr(TG, "generate_tests", fake_generate)
+    main(["--file", str(src), "--output", str(out), "--no-error-tests"])
+    assert config_values["include_error_paths"] is False
+
+
+def test_cli_no_benchmark_tests_flag(tmp_path, monkeypatch):
+    src = tmp_path / "a.py"
+    src.write_text("def foo():\n    return 1\n")
+    out = tmp_path / "tests"
+
+    config_values = {}
+
+    def fake_generate(self, file_path, output_dir):
+        config_values["include_benchmarks"] = self.config.include_benchmarks
+        return Path(output_dir) / "test_a.py"
+
+    monkeypatch.setattr(TG, "generate_tests", fake_generate)
+    main(["--file", str(src), "--output", str(out), "--no-benchmark-tests"])
+    assert config_values["include_benchmarks"] is False
+
+
+def test_cli_no_integration_tests_flag(tmp_path, monkeypatch):
+    src = tmp_path / "a.py"
+    src.write_text("def foo():\n    return 1\n")
+    out = tmp_path / "tests"
+
+    config_values = {}
+
+    def fake_generate(self, file_path, output_dir):
+        config_values["include_integration_tests"] = self.config.include_integration_tests
+        return Path(output_dir) / "test_a.py"
+
+    monkeypatch.setattr(TG, "generate_tests", fake_generate)
+    main(["--file", str(src), "--output", str(out), "--no-integration-tests"])
+    assert config_values["include_integration_tests"] is False
+
+
+def test_cli_config_file(tmp_path, monkeypatch):
+    src = tmp_path / "a.py"
+    src.write_text("def foo():\n    pass\n")
+    cfg = {"include_edge_cases": False}
+    cfg_path = tmp_path / ".testgen.config.json"
+    cfg_path.write_text(json.dumps(cfg))
+    out = tmp_path / "tests"
+
+    config_values = {}
+
+    def fake_generate(self, file_path, output_dir):
+        config_values["include_edge_cases"] = self.config.include_edge_cases
+        return Path(output_dir) / "test_a.py"
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(TG, "generate_tests", fake_generate)
+    main(["--file", str(src), "--output", str(out)])
+    assert config_values["include_edge_cases"] is False
+
+
+def test_cli_flag_overrides_config(tmp_path, monkeypatch):
+    src = tmp_path / "a.py"
+    src.write_text("def foo():\n    pass\n")
+    cfg = {"include_edge_cases": True}
+    cfg_path = tmp_path / ".testgen.config.json"
+    cfg_path.write_text(json.dumps(cfg))
+    out = tmp_path / "tests"
+
+    config_values = {}
+
+    def fake_generate(self, file_path, output_dir):
+        config_values["include_edge_cases"] = self.config.include_edge_cases
+        return Path(output_dir) / "test_a.py"
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(TG, "generate_tests", fake_generate)
+    main(["--file", str(src), "--output", str(out), "--no-edge-cases"])
+    assert config_values["include_edge_cases"] is False
+

--- a/tests/test_error_path_generation.py
+++ b/tests/test_error_path_generation.py
@@ -1,0 +1,21 @@
+from testgen_copilot.generator import TestGenerator, GenerationConfig
+
+
+def test_error_path_test_generated(tmp_path):
+    src = tmp_path / "mod.py"
+    src.write_text("""def f(x):\n    if x < 0:\n        raise ValueError('bad')\n    return x\n""")
+    out = tmp_path / "tests"
+    gen = TestGenerator(GenerationConfig(include_error_paths=True))
+    gen.generate_tests(src, out)
+    content = (out / "test_mod.py").read_text()
+    assert "pytest.raises(ValueError)" in content
+
+
+def test_error_path_tests_can_be_disabled(tmp_path):
+    src = tmp_path / "mod.py"
+    src.write_text("""def f(x):\n    if x < 0:\n        raise ValueError('bad')\n    return x\n""")
+    out = tmp_path / "tests"
+    gen = TestGenerator(GenerationConfig(include_error_paths=False))
+    gen.generate_tests(src, out)
+    content = (out / "test_mod.py").read_text()
+    assert "pytest.raises" not in content

--- a/tests/test_integration_generation.py
+++ b/tests/test_integration_generation.py
@@ -1,0 +1,23 @@
+from testgen_copilot.generator import TestGenerator, GenerationConfig
+
+
+def test_integration_test_generated(tmp_path):
+    src = tmp_path / "mod.py"
+    src.write_text("""def a():\n    return 1\n\n
+def b():\n    return a() + 1\n""")
+    out = tmp_path / "tests"
+    gen = TestGenerator(GenerationConfig(include_integration_tests=True))
+    gen.generate_tests(src, out)
+    content = (out / "test_mod.py").read_text()
+    assert "_integration" in content
+
+
+def test_integration_tests_can_be_disabled(tmp_path):
+    src = tmp_path / "mod.py"
+    src.write_text("""def a():\n    return 1\n\n
+def b():\n    return a() + 1\n""")
+    out = tmp_path / "tests"
+    gen = TestGenerator(GenerationConfig(include_integration_tests=False))
+    gen.generate_tests(src, out)
+    content = (out / "test_mod.py").read_text()
+    assert "_integration" not in content


### PR DESCRIPTION
## Summary
- support integration test generation
- allow disabling integration tests with `--no-integration-tests`
- document new option in CLI usage
- include config support for integration tests
- add tests for integration generation and CLI flag

## Testing
- `ruff check .`
- `bandit -r src | head`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860004fb4bc8329a4f248bc4b13b521

## Summary by Sourcery

Introduce support for integration, error-path, and benchmark test generation in the TestGenerator and expose controls via new CLI options, batch and watch modes, and configuration files, with corresponding tests and documentation updates.

New Features:
- Generate integration tests for modules with multiple functions
- Enable error-path and performance benchmark test generation
- Support batch generation of tests for all project files
- Implement watch mode with optional auto-generation and configurable polling
- Load settings from a config file and allow disabling specific test types via CLI flags

Enhancements:
- Add language-to-file-pattern mapping for batch and watch operations

Documentation:
- Update README with new CLI options, batch/watch usage, and config file examples

Tests:
- Add unit tests for integration, error-path, and benchmark generation toggles
- Add CLI tests for batch mode, watch mode, language patterns, config precedence, and disable flags